### PR TITLE
Bundle ordering

### DIFF
--- a/karaf-features-gen/src/main/groovy/com/github/lburgazzoli/gradle/plugin/KarafFeaturesGenPlugin.groovy
+++ b/karaf-features-gen/src/main/groovy/com/github/lburgazzoli/gradle/plugin/KarafFeaturesGenPlugin.groovy
@@ -19,17 +19,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 /**
- *
+ * karaf-features-gen plugin
  */
 class KarafFeaturesGenPlugin implements Plugin<Project> {
 
-    /**
-     *
-     * @param project
-     */
+
     @Override
     void apply(Project project) {
-        project.extensions.create("karafFeatures", KarafFeaturesGenTaskExtension)
-        project.task('generateKarafFeatures', type: KarafFeaturesGenTask)
+        project.extensions.create( KarafFeaturesGenTaskExtension.NAME, KarafFeaturesGenTaskExtension, project )
+        project.task( KarafFeaturesGenTask.NAME, type: KarafFeaturesGenTask )
     }
 }

--- a/karaf-features-gen/src/main/groovy/com/github/lburgazzoli/gradle/plugin/KarafFeaturesGenTaskExtension.groovy
+++ b/karaf-features-gen/src/main/groovy/com/github/lburgazzoli/gradle/plugin/KarafFeaturesGenTaskExtension.groovy
@@ -15,13 +15,28 @@
  */
 package com.github.lburgazzoli.gradle.plugin
 
+import org.gradle.api.Project
+
 /**
  * Extensions for KarafFeaturesGenTask
  */
 class KarafFeaturesGenTaskExtension {
+    public static final String NAME = 'karafFeatures'
+
     String[] excludes = [];
     String[] wraps = [];
     Map<String,String> startLevels = [:];
     File outputFile = null;
     List<String> extraBundles = [];
+    Set<Project> projects;
+
+    KarafFeaturesGenTaskExtension(Project project) {
+        // set up the defaults for projects array to maintain backwards compatibility...
+        if ( project.subprojects.size() > 0 ) {
+            projects = project.subprojects;
+        }
+        else {
+            projects = [project];
+        }
+    }
 }


### PR DESCRIPTION
This is the second pull request I mentioned.  This one alters the order in which the `<bundle/>` entries are created to be transitivity depth-first.  It builds on top of the other one I sent earlier, meaning you'd have to apply that one first, and then this one.